### PR TITLE
Don't use bash unless absolutely necessary. /bin/sh instead.

### DIFF
--- a/bubblegum/program/build-token-metadata.sh
+++ b/bubblegum/program/build-token-metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Simple script to build token-metdata and move it to the root
 # `test-programs` folder to load for banks client tests. This is

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function exists_in_list() {
     LIST=$1


### PR DESCRIPTION
This is a portability fix; `bash` isn't always guaranteed to be in `/bin/bash` on a POSIX system. `/bin/sh` is the better choice for this particular script.